### PR TITLE
Update agama project url in header and footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -74,7 +74,7 @@ const config: Config = {
           position: "left",
         },
         {
-          href: "https://github.com/openSUSE/agama",
+          href: "https://github.com/agama-project/agama",
           label: "GitHub",
           position: "right",
         },
@@ -105,7 +105,7 @@ const config: Config = {
           items: [
             {
               label: "GitHub",
-              href: "https://github.com/openSUSE/agama",
+              href: "https://github.com/agama-project/agama",
             },
             {
               label: "IRC",


### PR DESCRIPTION
Seems that agama project has moved from openSUSE project to a own project.