### PR TITLE
Fixed CSS build in production, correct dark theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,19 +27,19 @@
 
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+}
 
-  article a:where(:not(.button)) {
-    text-decoration: underline;
-  }
+article a:where(:not(.button)) {
+  text-decoration: underline;
+}
 
-  .flex-container {
-    display: flex;
-    gap: calc(var(--ifm-button-group-spacing) * 2);
-  }
+.flex-container {
+  display: flex;
+  gap: calc(var(--ifm-button-group-spacing) * 2);
+}
 
-  .footer--dark {
-    --ifm-footer-link-hover-color: var(--jungleGreenColor);
-  }
+.footer--dark {
+  --ifm-footer-link-hover-color: var(--jungleGreenColor);
 }
 
 /**
@@ -61,9 +61,14 @@
   --ifm-color-primary-lightest: #96e4bf;
   --ifm-background-color: #0c322c;
 
-  .footer--dark {
-    --ifm-footer-background-color: var(--ifm-navbar-background-color);
-  }
-
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  /*
+   * NOTE: Do not use nested rules here! The CSS minifier in the production
+   * builds does not handle that correctly. See the example rule below.
+   */
+}
+
+[data-theme="dark"] .footer--dark {
+  --ifm-footer-background-color: var(--ifm-navbar-background-color);
 }


### PR DESCRIPTION
## Problem

![dark_brokenpng](https://github.com/user-attachments/assets/42d890e9-a6eb-47ef-90da-a93de0b14524)

- The dark theme does not look right, the header text is hardly readable
- There are also some warnings printed during build, see [full log](https://github.com/agama-project/agama-project.github.io/actions/runs/11108592463/job/30861897748#step:5:12)
  ```
  Unexpected '}' at assets/css/styles.59e34a96.css
  Unexpected '}' at assets/css/styles.59e34a96.css
  Invalid property name 'article a' at assets/css/styles.59e34a96.css
  Invalid property name '.flex-container{display' at assets/css/styles.59e34a96.css
  Invalid property name '.footer--dark{--ifm-footer-background-color' at assets/css/styles.59e34a96.css
  Invalid selector '}.tabList__CuJ' at assets/css/styles.59e34a96.css
  Invalid selector '}.tabList__CuJ' at assets/css/styles.59e34a96.css
  ```
- After some testing and playing around I found out that the used CSS minifier does not like nested rules... :worried: 

## Notes

- Interestingly the problem does not happen when running in a development server (`yarn start`)
- The minifaction probably only happens in the production build (`yarn build`)
- BTW even the Docusaurus documentation suggests [this CSS style](https://docusaurus.io/docs/styling-layout#dark-mode) for the dark theme

## Fix

- After moving the nested CSS rules outside it works fine and no warning is printed
![dark_fixed](https://github.com/user-attachments/assets/cca06b23-3a6d-4b60-9bc8-87515eaa7010)
