### PR TITLE
Image carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "prism-react-renderer": "^2.3.0",
     "raw-loader": "^4.0.2",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-responsive-carousel": "^3.2.23"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.5.2",

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -4,6 +4,10 @@ import BrowserWindow from "@site/src/components/BrowserWindow";
 import clsx from "clsx";
 import profile from "!!raw-loader!@site/static/profiles/tw.json";
 
+// image carousel
+import "react-responsive-carousel/lib/styles/carousel.min.css";
+import { Carousel } from "react-responsive-carousel";
+
 import styles from "./styles.module.css";
 
 type FeatureItem = {
@@ -29,7 +33,32 @@ const FeatureList: FeatureItem[] = [
     ),
     asset: (
       <BrowserWindow aria-hidden url="https://agama.local" paddingLess>
-        <img src={require("@site/static/img/storage.png").default} />
+        <Carousel
+          autoPlay
+          infiniteLoop
+          showStatus={false}
+          showThumbs={false}
+          interval={5000}
+        >
+          <div>
+            <img src={require("@site/static/img/user/overview.png").default} />
+          </div>
+          <div>
+            <img src={require("@site/static/img/user/users.png").default} />
+          </div>
+          <div>
+            <img src={require("@site/static/img/storage.png").default} />
+          </div>
+          <div>
+            <img src={require("@site/static/img/user/network.png").default} />
+          </div>
+          <div>
+            <img src={require("@site/static/img/user/software.png").default} />
+          </div>
+          <div>
+            <img src={require("@site/static/img/user/install-button.png").default} />
+          </div>
+        </Carousel>
       </BrowserWindow>
     ),
   },
@@ -86,7 +115,7 @@ function Feature({ title, asset, description }: FeatureItem) {
   return (
     <li>
       {asset}
-      <div>
+      <div className={clsx(styles.descriptionBlock)}>
         <Heading as="h2">{title}</Heading>
         <p>{description}</p>
       </div>

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -94,7 +94,7 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
         Automate the installation process using either the command-line
-        interface or the HTTP API and integrate it into your worklow.
+        interface or the HTTP API and integrate it into your workflow.
       </>
     ),
     asset: (

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -21,6 +21,10 @@
   max-block-size: 400px;
 }
 
+.descriptionBlock {
+  min-width: 30%;
+}
+
 @media screen and (min-width: 996px) {
   .features li {
     flex-direction: row;

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -39,3 +39,14 @@
     max-inline-size: 35vw;
   }
 }
+
+/*
+ * Carousel fixes (revert some of the styling above) in .carousel
+ */
+:global .carousel .control-dots .dot, :global .carousel li.slide {
+  padding-block-start: 0;
+}
+
+:global .carousel li img {
+  max-inline-size: none;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -43,17 +43,6 @@ article a:where(:not(.button)) {
 }
 
 /*
- * Carousel fixes (revert some of the HomepageFeatures styling)
- */
-.carousel .control-dots .dot, .carousel li.slide {
-  padding-block-start: 0;
-}
-
-.container .carousel li img {
-  max-inline-size: none;
-}
-
-/*
  * Carousel styling
  */
 .carousel .control-dots .dot.selected {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -75,7 +75,7 @@ article a:where(:not(.button)) {
  *
  * NOTE: #40ce8a is a lighter variant of SUSE Jungle Green color (#30BA78).
  * Needed such a lighter version as primary color in order to achieve
- * acceptable constrast ratings for the other dark and light variants.
+ * acceptable contrast ratings for the other dark and light variants.
  * Variants calculated with the help of
  * https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima
  */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -42,6 +42,34 @@ article a:where(:not(.button)) {
   --ifm-footer-link-hover-color: var(--jungleGreenColor);
 }
 
+/*
+ * Carousel fixes (revert some of the HomepageFeatures styling)
+ */
+.carousel .control-dots .dot, .carousel li.slide {
+  padding-block-start: 0;
+}
+
+.container .carousel li img {
+  max-inline-size: none;
+}
+
+/*
+ * Carousel styling
+ */
+.carousel .control-dots .dot.selected {
+  background-color: var(--ifm-color-primary-lightest);
+}
+
+.container .carousel .control-next.control-arrow:before
+{
+  border-left-color: var(--ifm-color-primary);
+}
+
+.container .carousel .control-prev.control-arrow:before
+{
+  border-right-color: var(--ifm-color-primary);
+}
+
 /**
  * For readability concerns, you should choose a lighter palette in dark mode
  *

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,7 +38,7 @@ export default function Home(): JSX.Element {
       <main>
         <HomepageFeatures />
         <div
-          className="contianer text--center margin-vert--xl"
+          className="container text--center margin-vert--xl"
           style={{ width: "100%" }}
         >
           <Link

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,6 +2991,11 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
+classnames@^2.2.5:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clean-css@^5.2.2, clean-css@^5.3.2, clean-css@~5.3.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"
@@ -7343,7 +7348,7 @@ prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7494,6 +7499,13 @@ react-dom@^18.0.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-easy-swipe@^0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz#ce9384d576f7a8529dc2ca377c1bf03920bac8eb"
+  integrity sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -7547,6 +7559,15 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==
   dependencies:
     "@types/react" "*"
+
+react-responsive-carousel@^3.2.23:
+  version "3.2.23"
+  resolved "https://registry.yarnpkg.com/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz#4c0016ff54603e604bb5c1f9e7ef2d1eda133f1d"
+  integrity sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.5.8"
+    react-easy-swipe "^0.0.21"
 
 react-router-config@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
## Problem

- The main page is too static IMHO, let make it a bit live with image carousel :carousel_horse: 
- We already have the screenshots, so let's use them more!

## Solution

- Use [react-responsive-carousel](https://github.com/leandrowd/react-responsive-carousel) for changing the screenshots
- The description width set to min. 30%, it was too narrow in some screen sizes
- Additionally fixed some typos

## Screen recording

https://github.com/user-attachments/assets/7b24f1e5-a7e8-41a8-a680-dbffcc60cddb

