### PR TITLE
Blog post documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,18 @@ $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+### Blog
+
+To create a new blog post run the [create_blog_post](create_blog_post) script with a short title as
+the argument, for example:
+
+```bash
+./create_blog_post "New blog post!"
+```
+
+The title is used in the created file name and in the post URL so use something short and
+meaningful. The blog post itself then can contain a longer title specified in the `title` front
+matter.
+
+See more details about writing blog posts in the [blog.md](blog.md) document.

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,107 @@
+# Agama blog
+
+Here are some suggestions and hints for writing the Agama blog posts.
+
+## Style guide
+
+We do not have any special blog style guide besides few rules mentioned below, just use common
+sense. If you are unsure about something you can check one of these general developer documentation
+style guides:
+
+- https://developers.google.com/style
+- https://docs.microsoft.com/style-guide/welcome/
+
+## Front matter
+
+The [front matter](https://docusaurus.io/docs/markdown-features#front-matter) is the YAML metadata
+block at beginning of the MDX file enclosed in the `---` markers.
+
+- The list of tags is defined in the [blog/tags.yml](blog/tags.yml) file, feel free to add new tags
+  whenever needed
+- The blog post publish date is taken from the file name, if there are multiple posts in the same
+  day you can use the [date](https://docusaurus.io/docs/blog#blog-post-date) front matter to specify
+  the time more precisely
+- If the blog post is a generic announcement on behalf of the whole team (e.g. a new Agama release)
+  then do not specify the blog post author. If it is a specific post by a single author then use the
+  [author](https://docusaurus.io/docs/blog#inline-authors) tag in the front matter.
+- See more details in the
+  [documentation](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog#markdown-front-matter)
+
+## Style
+
+- Use [sentence style capitalization](
+  https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings) in the
+  heading and titles
+- Add a short heading anchor explicitly, although Docusaurus generates them automatically using a
+  predefined anchor avoids changing it after fixing a typo or rewording
+
+## Syntax highlighting
+
+Syntax highlighting in code blocks works with the usual three backticks followed by the language name.
+
+    ```json
+    {
+      "search": "/dev/vda1",
+      "delete": true
+    }
+    ```
+
+Not all languages are enabled by default, if your code is not highlighted for a specific language
+then very likely it is not enabled. Check the supported languages in
+`node_modules/prismjs/components/prism-*.js` files and enable the language in the
+[docusaurus.config.ts](docusaurus.config.ts) configuration file at the `additionalLanguages` key.
+
+## Images
+
+Place the images into the `static/img/blog/XXXX-YY-ZZ` directory and reference them using the usual
+Markdown syntax:
+
+    ![Detailed image description](../static/img/blog/XXXX-YY-ZZ/image.png)
+
+If the image is too large and you want to display it smaller or you want to display two images
+side-by-side then use the `SmallImageBox` custom component for that:
+
+    import SmallImageBox from "@site/src/components/SmallImageBox";
+
+    <SmallImageBox>
+      ![Image1](../static/img/blog/XXXX-YY-ZZ/image1.png)
+      ![Image2](../static/img/blog/XXXX-YY-ZZ/image2.png)
+    </SmallImageBox>
+
+## Docusaurus admonitions
+
+Docusaurus support using [admonitions](https://docusaurus.io/docs/markdown-features/admonitions),
+fancy information boxes.
+
+    :::warning
+
+    Important warning!
+
+    :::
+
+Note: The empty lines around the text are important!
+
+## Anchors
+
+Docusaurus generates anchors for all headings automatically. But in some cases you might need to
+reference something else, for example an image or code snippet.
+
+In that case use the React component for placing the anchor
+
+    <a id="my-anchor"></a>
+
+and reference it with
+
+    <a href="#my-anchor">link</a>
+
+Do not use the usual Markdown link, Docusaurus then reports a false positive warning about missing
+anchor definition. It seems that it checks only for the Markdown anchors and not for the anchors
+added by the React components...
+
+Make sure the ID is unique and does not conflict with some automatically generated heading anchor.
+
+## Referencing
+
+For referencing another blog post just use the full file name and optional anchor, for example:
+
+    In Agama 9 we [fixed locking](2024-06-28-agama-9.mdx#live-iso)

--- a/create_blog_post
+++ b/create_blog_post
@@ -1,0 +1,47 @@
+#! /bin/bash
+
+if [ -z "$1" ]; then
+  echo "Error: Missing argument"
+  echo
+  echo "Usage:"
+  echo "  $0 <short-title>"
+  echo
+  echo "Example:"
+  echo "  $0 \"New blog post\""
+
+  exit 1
+fi
+
+# convert the title to a file name
+title=$(echo -n "$1" | tr "[:upper:]" "[:lower:]" | tr "[:space:]" "-" | tr -d -c "[:alnum:]-" )
+# current date in YYYY-MM-DD format
+date=$(date +%F)
+# blog post MDX file
+mdx="blog/${date}-${title}.mdx"
+# directory for storing images
+img="static/img/blog/$date"
+
+cat <<EOF > "$mdx"
+---
+title: $1
+tags:
+  - release
+---
+
+This is a template for Agama blog posts. All text above the "truncate" comment is displayed also in
+the blog index page as a summary.
+
+{/* truncate */}
+
+## Heading {#heading}
+
+Place images into the \`static/img/blog/$date\` directory and insert them with this Markdown:
+
+![Image description](../static/img/blog/$date/image.png)
+
+See the blog.md file for more details about writing blog posts.
+EOF
+echo "Created blog post:  $mdx"
+
+mkdir -p "$img"
+echo "Image directory:    $img"


### PR DESCRIPTION
## Changes

- Added documentation about writing blog posts
- Added helper `create_blog_post` script for generating a template for new blog posts

## Notes

Originally I wanted to use the [docusaurus-post-generator](https://github.com/moojing/docusaurus-post-generator) plugin for creating new blog posts. But it turned out to be too simple and limited (e.g . it can only create a .md file while we use the .mdx suffix for the posts, it cannot create the image directory, etc...). A trivial bash script can do more with greater flexibility.