### PR TITLE
Do not show discussions in the blog index page

### DIFF
--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -20,8 +20,10 @@ export default function BlogPostItemWrapper(props: Props): JSX.Element {
   // use "discussion: false" to disable discussion in a specific post
   const discussionEnabled = frontMatter.discussion !== false;
 
-  // if discussion is disabled then just return the standard blog page content
-  if (!discussionEnabled) return <BlogPostItem {...props} />;
+  // if discussion is disabled then just return the standard blog page content,
+  // do not show the discussions in the blog index page
+  if (!discussionEnabled || !useBlogPost().isBlogPostPage)
+    return <BlogPostItem {...props} />;
 
   const discussionId =
     frontMatter.discussion_id && Number(frontMatter.discussion_id);
@@ -88,10 +90,7 @@ export default function BlogPostItemWrapper(props: Props): JSX.Element {
     <>
       <BlogPostItem {...props} />
       <hr />
-      <h2
-        className={`anchor ${styles.anchorWithStickyNavbar}`}
-        id="comments"
-      >
+      <h2 className={`anchor ${styles.anchorWithStickyNavbar}`} id="comments">
         Comments
         <a
           href="#comments"


### PR DESCRIPTION
## Problem

- The blog discussions were also displayed in the blog index page

## Fix

- Check if this is a blog post page

## Test

- See preview at https://agama-preview-pull-25.surge.sh/blog