### PR TITLE
Clarify inst.finish=stop

### DIFF
--- a/docs/user/boot_options.md
+++ b/docs/user/boot_options.md
@@ -65,8 +65,10 @@ first one can be removed anytime.
 - `inst.finish`
   During an unattended installation, if the installation is completed successfully then the
   installer will reboot into the target system by default (`reboot`). This behavior can be modified
-  allowing to `stop`, `halt` or `poweroff` the machine at the end of the installation. An
-  interactive installation is not affected by this parameter.
+  allowing to `halt` or `poweroff` the machine at the end of the installation.
+  In addition to the three values corresponding to systemd commands, the value `stop` will
+  only stop the installer, leaving the machine running.
+  An interactive installation is not affected by this parameter.
 
   ```text
   inst.finish=poweroff

--- a/docs/user/boot_options.md
+++ b/docs/user/boot_options.md
@@ -67,7 +67,8 @@ first one can be removed anytime.
   installer will reboot into the target system by default (`reboot`). This behavior can be modified
   allowing to `halt` or `poweroff` the machine at the end of the installation.
   In addition to the three values corresponding to systemd commands, the value `stop` will
-  only stop the installer, leaving the machine running.
+  pause at the final "Congratulations! [Reboot]" screen, allowing you to
+  extract logs.
   An interactive installation is not affected by this parameter.
 
   ```text

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -329,8 +329,8 @@ Finish the installation rebooting the system by default
 Possible values:
 
 - `stop`:
-  Stop at the end of the installation
-- `reboot`:
+  Stop the installer at the end of the installation but leave the machine running
+- `reboot` (default):
   Reboot into the installed system
 - `halt`:
   Halt the installed machine

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -329,7 +329,8 @@ Finish the installation rebooting the system by default
 Possible values:
 
 - `stop`:
-  Stop the installer at the end of the installation but leave the machine running
+  Stop the installation at its end, at the "Congratulations! [Reboot]" screen,
+  leaving the backend running
 - `reboot` (default):
   Reboot into the installed system
 - `halt`:


### PR DESCRIPTION
mention that the others correspond to systemd commands

<details>
<summary>(here my initial misconceptions and questions about `stop`)</summary>
TODO: as a user I would like to know some more info about `stop`.
Presumably this is a debugging option when I am doing a test and want to inspect the system. 
I assume that the web service will stop and the web UI will no longer work? Agama CLI will not work?
So I should log in at the console, that's my only option?
To continue, I should tell systemd to `reboot`, `poweroff` or `halt`?

We may also say that `stop` is an intermediate state that we don't want to overspecify.
</details>