### PR TITLE
remove stale live.password_dialog and live.password_systemd

### DIFF
--- a/docs/devel/live_iso.md
+++ b/docs/devel/live_iso.md
@@ -106,13 +106,13 @@ You can define the password directly on the boot command line. There are two opt
 You can enter your password during boot in an interactive session. Again, there
 are two options:
 
-- Use `live.password_dialog` boot option to start an interactive dialog during the boot process.
+- Use `live.password_dialog=1` boot option to start an interactive dialog during the boot process.
   This uses a nice dialog for entering and confirming the password. However, in some situations the
   full screen dialog might not be displayed correctly or some messages might be displayed over it. In
   that case you might use the `Ctrl+L` key shortcut to refresh the screen. If it still does not work
   then try using the other option below.
 
-- Use `live.password_systemd` boot option to ask for the password in a simple prompt. This is
+- Use `live.password_systemd=1` boot option to ask for the password in a simple prompt. This is
   similar to the option above, but the advantage is that this solution does not use a full screen
   dialog but a single line prompt so it should work better in special environments like a serial
   console.

--- a/docs/user/boot_options/index.md
+++ b/docs/user/boot_options/index.md
@@ -114,24 +114,22 @@ inst.dud=label://UPDATES/package.rpm
   avoids accidentally using the default password from the medium.
   :::
 
-- `live.password_dialog` Start an interactive dialog during the boot process. This uses a nice
+- `live.password_dialog=1` Start an interactive dialog during the boot process. This uses a nice
   dialog for entering and confirming the password. However, in some situations the full screen dialog
   might not be displayed correctly or some messages might be displayed over it. In that case you might
   use the `Ctrl+L` key shortcut to refresh the screen. If it still does not work then try using the
   other option below.
 
   ```text
-  live.password_dialog
   live.password_dialog=1
   ```
 
-- `live.password_systemd` Ask for a password using a simple prompt. This is
+- `live.password_systemd=1` Ask for a password using a simple prompt. This is
   similar to the option above, but the advantage is that this solution does not use a full screen
   dialog but a single line prompt so it should work better in special environments like a serial
   console.
 
   ```text
-  live.password_systemd
   live.password_systemd=1
   ```
 


### PR DESCRIPTION
Only key=value is now recognized, where value must be '1'.