### PR TITLE
Add doc for inst.copy_network boot option

### DIFF
--- a/docs/user/boot_options/index.md
+++ b/docs/user/boot_options/index.md
@@ -38,6 +38,13 @@ first one can be removed anytime.
   inst.config_url=usb:///agama.yaml
   ```
 
+- `inst.copy_network`: whether the NetworkManager persistent system connections should be copied to
+  the target system at the end of the installation or not. The copy is enabled by default.
+
+  ```text
+  inst.copy_network=0
+  ```
+
 - `inst.dud`
   Allows to patch or extend the Live Media by pointing to so called Driver Update. It currently
   supports only RPM packages. See more about supported URLs at [URLs section](/docs/user/urls).
@@ -54,7 +61,7 @@ inst.dud=label://UPDATES/package.rpm
   more options for Agama and typing them during boot is not possible.
 
   ```text
-  agama.info=ftp://myserver/devel.info
+  inst.info=ftp://myserver/devel.info
   ```
 
   :::note


### PR DESCRIPTION
Add documentation for the new `inst.copy_network` boot option introduced by https://github.com/agama-project/agama/pull/2291