### PR TITLE
Fix discussion ID for the latest blog post

### DIFF
--- a/blog/2025-05-27-agama-15.mdx
+++ b/blog/2025-05-27-agama-15.mdx
@@ -1,6 +1,6 @@
 ---
 title: Releasing version 15
-discussion_id: 42 # ID title "blog/2025/05/26/agama-15" from https://github.com/agama-project/agama-project.github.io/discussions/<ID>
+discussion_id: 79
 tags:
   - release
 ---


### PR DESCRIPTION
I forgot to create the discussion and adjust the ID while publishing the blog post for Agama 15.