### PR TITLE
mention relative references, as replacement for relurl

### DIFF
--- a/docs/user/urls.md
+++ b/docs/user/urls.md
@@ -34,6 +34,23 @@ can be a relative reference, where the resolution base is the URL of the contain
 
 This is a replacement for the ~~`relurl`~~ scheme used in AutoYaST.
 
+For example, if the configuration below is retrieved from
+`https://example.com/machines/sles16.jsonnet`, it refers to
+`https://example.com/machines/scripts/snapshot.sh`.
+
+```jsonnet
+{
+  scripts: {
+    postPartitioning: [
+      {
+        name: "snapshot",
+        url: "scripts/snapshot.sh"
+      }
+    ]
+  }
+}
+```
+
 ## Agama specific schemes
 
 The typical protocols are enough for most use cases. However, more specific URLs can be handy in

--- a/docs/user/urls.md
+++ b/docs/user/urls.md
@@ -27,6 +27,13 @@ In addition to those schemes, Agama supports a set of specific ones which can be
 - [`label`](#label) for finding files in a file system with a given label.
 - [`cd`, `dvd`, `hd`](#cd-dvd-and-hd) for finding files on specific devices (prefer `device`).
 
+## Relative references
+
+For `"scripts"` and `"files"` in the Agama JSON config, the `"url"` property
+can be a relative reference, where the resolution base is the URL of the containing config.
+
+This is a replacement for the ~~`relurl`~~ scheme used in AutoYaST.
+
 ## Agama specific schemes
 
 The typical protocols are enough for most use cases. However, more specific URLs can be handy in
@@ -97,7 +104,7 @@ advantage, using `device` might be a better option.
 
 ### Not supported yet
 
-The `repo://` and `relurl://` URLs are not supported yet, but there are plans to implement them.
+The `repo://` URLs are not supported yet, but there are plans to implement them.
 
 [^1]: Agama relies on [curl](https://curl.se/) to support generic protocols (network protocols and
     `file://`). So it might happen that some protocol is supported "by accident". However, only the

--- a/docs/user/urls.md
+++ b/docs/user/urls.md
@@ -90,8 +90,10 @@ hd:/sles.jsonnet?devices=/dev/sr0
 dvd:/autoinst.xml?devices=sr1
 ```
 
-:::note Prefer `device` to `cd`, `dvd` or `hd` Given that `cd`, `dvd` and `hd` do not offer any
-advantage, using `device` might be a better option. :::
+:::note
+Prefer `device` to `cd`, `dvd` or `hd` Given that `cd`, `dvd` and `hd` do not offer any
+advantage, using `device` might be a better option.
+:::
 
 ### Not supported yet
 


### PR DESCRIPTION
Implemented in https://github.com/agama-project/agama/pull/2305 , and Leo M from QA found that this piece of docs was not updated for that.

Rendered at: https://agama-project.github.io/docs/user/urls

Looking at that page, I also found a rendering problem at the bottom, fixing that too.