### PR TITLE
Update index.md

### DIFF
--- a/docs/user/interactive/index.md
+++ b/docs/user/interactive/index.md
@@ -17,8 +17,8 @@ the installation workflow.
 ### Product selection
 
 Agama allows installing several SUSE and openSUSE-based distributions. The [openSUSE-based
-image](/download) image includes [openSUSE Tumbleweed](https://www.opensuse.org/#Tumbleweed),
-[openSUSE Leap 16.0 Alpha](https://www.opensuse.org/#Leap) and [openSUSE Micro
+image](/download) image includes [Tumbleweed](https://www.opensuse.org/#Tumbleweed),
+[Leap 16.0 Beta](https://get.opensuse.org/leap/16.0/), [Leap Micro 6.2 Beta](https://en.opensuse.org/Portal:Leap_Micro), [Slowroll](https://en.opensuse.org/Portal:Slowroll), [Kalpa](https://kalpadesktop.org/) and [openSUSE Micro
 OS](https://get.opensuse.org/microos/).
 
 It is noteworthy to mention that the product selection does not only determine which software we


### PR DESCRIPTION
+ Added Leap Micro 6.2 Beta with Link to Leap Micro wiki page, since there is no get-o-o page for the beta as of 7/10/25
+ Added Slowroll with Link to Slowroll wiki page, since there is no get-o-o for this project as of 7/10/25
+ Added Kalpa with link to kalpadesktop.com since there is no get-o-o page for this project as of 7/10/25
+ Changed Leap 16.0 Alpha to Beta since the product has moved into a beta state
+ Changed Leap 16.0 Link to direct user to the 16.0 beta download page of get-o-o 

- Removed the word 'openSUSE' from product names. most if not all of these products dont use it within their respective titles

Note: please let me know if there is anything the agama team would prefer to change, etc.