### PR TITLE
add documentation for zfcp and dasd profile sections

### DIFF
--- a/docs/user/unattended/profile/dasd.md
+++ b/docs/user/unattended/profile/dasd.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 12
+---
+
+# DASD Device Management
+
+Agama allows you to manage DASD (Direct Access Storage Device) activation and deactivation during an unattended installation. This feature is configured within the `dasd` section using the `devices` key.
+
+## Configuring DASD Devices
+
+To specify DASD devices and their desired states, use a list of objects under `dasd.devices`. Each object represents a single DASD device and supports the following options:
+
+  * **`channel`**: The unique channel ID of the DASD device (e.g., `"0.0.0200"`). This is a required entry.
+
+  * **`state`**: Defines the desired state of the device.
+
+      * `"active"`: Agama will attempt to activate the device if it's not already active. This is the **default** value.
+      * `"offline"`: Agama will deactivate the device if it's currently active.
+
+  * **`format`**: Controls whether the device should be formatted.
+
+      * `true`: The device will always be formatted, even if it's already formatted.
+      * `false`: The device will never be formatted. **Caution**: This can result in an unusable device if it's not already formatted.
+      * If this option is not specified, Agama will only format the device if it's not already formatted.
+
+  * **`diag`**: Specifies the value of the `diag` flag for the device.
+
+      * If this option is not specified, the device's current `diag` flag setting will be preserved.
+      * **Warning**: Use this option with extreme caution and only if you fully understand its implications. On some mainframes, incorrectly setting the `diag` flag can lead to unexpected behavior, including device deactivation.
+
+## Example Configuration
+
+The following example demonstrates how to activate and format one DASD device, and deactivate another:
+
+```jsonnet
+{
+  dasd: {
+    devices: [
+      {
+        channel: "0.0.0200",
+        format: true,
+        state: "active"
+      },
+      {
+        channel: "0.0.0201",
+        state: "offline"
+      }
+    ]
+  }
+}
+```

--- a/docs/user/unattended/profile/zfcp.md
+++ b/docs/user/unattended/profile/zfcp.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 13
+---
+
+# ZFCP Device Management
+
+Agama provides functionality to activate zFCP (Fibre Channel Protocol) disks as part of an unattended installation. This feature is configured within the `zfcp` section of your configuration, specifically under the `devices` key.
+
+## Activating ZFCP Disks
+
+To activate zFCP disks, you must define a list of objects under `zfcp.devices`. Each object in this list represents a single zFCP disk and requires the following options to uniquely identify the desired disk:
+
+  * **`channel`**: The channel ID of the zFCP controller (e.g., `"0.0.fa00"`).
+  * **`wwpn`**: The World Wide Port Name (WWPN) of the target port (e.g., `"0x500507630300c562"`).
+  * **`lun`**: The Logical Unit Number (LUN) of the SCSI device (e.g., `"0x4010403300000000"`).
+
+All of these options are mandatory to correctly identify and activate the specified zFCP disk.
+
+## Example Configuration
+
+The following example demonstrates how to configure a zFCP disk for activation:
+
+```jsonnet
+{
+  zfcp: {
+    devices: [
+      {
+        channel: "0.0.fa00",
+        wwpn: "0x500507630300c562",
+        lun: "0x4010403300000000"
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
Add parts for zFCP and DASD parts of agama profile.
iSCSI is also missing, but after checking schema and examples, I feel it will be better documented by @joseivanlopez who implemented it as I am not sure about some defaults and proper terminology.

Wait with merge for https://github.com/agama-project/agama/pull/2551