### PR TITLE
Remove '#' character from the ID and add delete section

### DIFF
--- a/docs/user/unattended/profile/network.md
+++ b/docs/user/unattended/profile/network.md
@@ -229,8 +229,8 @@ one specially when it is already applied to an specific interface.
       },
       {
         "id": "enp1s0",
-        "interface": "enp1s0"
-        "status": "up",
+        "interface": "enp1s0",
+        "status": "up"
       }
     ]
   }


### PR DESCRIPTION
## Description

We had a problems in the backend when using special characters in the connection IDs. There is a fix already https://github.com/agama-project/agama/pull/2605 but it is preferable to remove them also from the examples.

It is also reasonable to delete some unwanted connections specially when some interface is planned to be part of a controller connection like a bridge or a bond. Therefore, we have also added that section.

- https://trello.com/c/H8mxZJxy/5185-2-agama-loading-a-profile-tries-to-create-an-existing-network-

The preview rendered version can be checked [here](https://agama-preview-pull-101.surge.sh/docs/user/unattended/profile/network)