### PR TITLE
Improved download links

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "raw-loader": "^4.0.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-responsive-carousel": "^3.2.23"
+    "react-responsive-carousel": "^3.2.23",
+    "xbytes": "^1.9.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.6.3",

--- a/src/components/DownloadLinks/index.tsx
+++ b/src/components/DownloadLinks/index.tsx
@@ -1,0 +1,109 @@
+import React, { JSX, useEffect, useState } from "react";
+import xbytes from "xbytes";
+
+/* architecture header */
+const ArchHeader = ({ arch }): JSX.Element => (
+  <h3 id={`download-${arch}`}>{arch}</h3>
+);
+
+/* progress indicator */
+const Loading = (): JSX.Element => (
+  <p>
+    <em>Loading data...</em>
+  </p>
+);
+
+/* show a download link for a specified architecture */
+/*  arch - the architecture name */
+/*  files - data downloaded from OBS */
+const DownloadLink = ({ arch, files }): JSX.Element => {
+  const file = files?.find((f) => f.name.includes(arch));
+  // base URL where the images are located
+  const url =
+    "https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso";
+
+  return (
+    <p>
+      {file ? (
+        /* found matching image, display the versioned link and the image size */
+        <>
+          <a href={`${url}/${file.name}`}>{file.name}</a>
+          {" ("}
+          {/* one decimal place in the formatted size */}
+          {xbytes(file.size, { fixed: 1 })}
+          {")"}
+        </>
+      ) : (
+        /* download failed or missing data, display a generic static link without version */
+        <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
+          {`agama-installer.${arch}-openSUSE.iso`}
+        </a>
+      )}
+      <br />
+      {file ? (
+        <a href={`${url}/${file.name}.sha256`}>{`${file.name}.sha256`}</a>
+      ) : (
+        <a href={`${url}/agama-installer.${arch}-openSUSE.iso.sha256`}>
+          {`agama-installer.${arch}-openSUSE.iso.sha256`}
+        </a>
+      )}
+    </p>
+  );
+};
+
+export default function DownloadLinks(): JSX.Element {
+  // this variable contains the downloaded data from OBS
+  //   undefined => data not loaded yet (display loading status)
+  //   empty array => download failed or timed out or invalid data was returned
+  //     (display generic unversioned links)
+  const [files, setFiles] = useState();
+
+  // unfortunately the direct download from the download.opensuse.org server does not work because
+  // of the CORS policy, as a workaround use a CORS proxy deployed in the Google Firebase cloud for
+  // downloading the data
+  // see https://github.com/lslezak/cors-proxy/blob/main/functions/index.js
+  // it just forwards the data from
+  // https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso/?jsontable
+  const corsProxy = "https://corsproxy-kcuoblmnuq-uc.a.run.app/";
+
+  const loadData = () => {
+    // if the data is not loaded in 2 seconds then display the generic links
+    const timer = setTimeout(() => !files && setFiles([]), 2000);
+    // download data from the OBS server
+    fetch(corsProxy)
+      .then((response) => response.json())
+      .then((json) => {
+        // keep only the openSUSE ISO image data, we do not care about the rest
+        const data = json.data.filter((f) =>
+          f.name.match(/^agama-installer\..*-openSUSE-Build.*\.iso$/)
+        );
+        console.log("Downloaded OBS data:", data);
+        setFiles(data);
+      })
+      .catch((err) => {
+        console.error("OBS download failed:", err);
+        setFiles([]);
+      })
+      .finally(() => clearTimeout(timer));
+  };
+
+  useEffect(() => {
+    loadData();
+    // refresh every 15 minutes to have up to date links when the page is displayed for a long time
+    const timer = setInterval(() => loadData(), 15 * 60 * 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <>
+      <ArchHeader arch="x86_64" />
+      {files ? <DownloadLink arch="x86_64" files={files} /> : <Loading />}
+      <ArchHeader arch="aarch64" />
+      {files ? <DownloadLink arch="aarch64" files={files} /> : <Loading />}
+      <ArchHeader arch="ppc64le" />
+      {files ? <DownloadLink arch="ppc64le" files={files} /> : <Loading />}
+      <ArchHeader arch="s390x" />
+      {files ? <DownloadLink arch="s390x" files={files} /> : <Loading />}
+    </>
+  );
+}

--- a/src/components/DownloadLinks/index.tsx
+++ b/src/components/DownloadLinks/index.tsx
@@ -67,8 +67,8 @@ export default function DownloadLinks(): JSX.Element {
   const corsProxy = "https://corsproxy-kcuoblmnuq-uc.a.run.app/";
 
   const loadData = () => {
-    // if the data is not loaded in 2 seconds then display the generic links
-    const timer = setTimeout(() => !files && setFiles([]), 2000);
+    // if the data is not loaded in 5 seconds then display the generic links
+    const timer = setTimeout(() => !files && setFiles([]), 5000);
     // download data from the OBS server
     fetch(corsProxy)
       .then((response) => response.json())

--- a/src/components/DownloadLinks/index.tsx
+++ b/src/components/DownloadLinks/index.tsx
@@ -1,21 +1,21 @@
 import React, { JSX, useEffect, useState } from "react";
 import xbytes from "xbytes";
 
-/* architecture header */
+// architecture header
 const ArchHeader = ({ arch }): JSX.Element => (
   <h3 id={`download-${arch}`}>{arch}</h3>
 );
 
-/* progress indicator */
+// progress indicator
 const Loading = (): JSX.Element => (
   <p>
     <em>Loading data...</em>
   </p>
 );
 
-/* show a download link for a specified architecture */
-/*  arch - the architecture name */
-/*  files - data downloaded from OBS */
+// show a download link for a specified architecture
+//  arch - the architecture name
+//  files - data downloaded from OBS
 const DownloadLink = ({ arch, files }): JSX.Element => {
   const file = files?.find((f) => f.name.includes(arch));
   // base URL where the images are located
@@ -25,7 +25,7 @@ const DownloadLink = ({ arch, files }): JSX.Element => {
   return (
     <p>
       {file ? (
-        /* found matching image, display the versioned link and the image size */
+        // found matching image, display the versioned link and the image size
         <>
           <a href={`${url}/${file.name}`}>{file.name}</a>
           {" ("}
@@ -34,7 +34,7 @@ const DownloadLink = ({ arch, files }): JSX.Element => {
           {")"}
         </>
       ) : (
-        /* download failed or missing data, display a generic static link without version */
+        // download failed or missing data, display a generic static link without version
         <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
           {`agama-installer.${arch}-openSUSE.iso`}
         </a>
@@ -51,6 +51,7 @@ const DownloadLink = ({ arch, files }): JSX.Element => {
   );
 };
 
+// show download links for all supported architectures
 export default function DownloadLinks(): JSX.Element {
   // this variable contains the downloaded data from OBS
   //   undefined => data not loaded yet (display loading status)

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -1,9 +1,8 @@
-import React, {useEffect, useState} from "react";
-import xbytes from "xbytes";
-
 import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+
+import DownloadLinks from "@site/src/components/DownloadLinks";
 
 export const HelpLinks = ({ dvdHelp, usbHelp }) => (
   <div className="flex-container">
@@ -15,108 +14,6 @@ export const HelpLinks = ({ dvdHelp, usbHelp }) => (
     </Link>
   </div>
 );
-
-{/* architecture header */}
-export const ArchHeader = ({arch}) => <h3 id={`download-${arch}`}>{arch}</h3>;
-
-{/* progress indicator */}
-export const Loading = () => <p><em>Loading data...</em></p>;
-
-{/* show a download link for a specified architecture */}
-{/*  arch - the architecture name */}
-{/*  files - data downloaded from OBS */}
-export const DownloadLink = ({arch, files}) => {
-  const file = files?.find(f => f.name.includes(arch));
-  // base URL where the images are located
-  const url = "https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso";
-
-  return (
-    <p>
-      { file ?
-        /* found matching image, display the versioned link and the image size */
-        <>
-          <a href={`${url}/${file.name}`}>
-            {file.name}
-          </a>
-          { " (" }
-          { /* one decimal place in the formatted size */}
-          { xbytes(file.size, {fixed: 1}) }
-          { ")" }
-        </>
-        :
-        /* download failed or missing data, display a generic static link without version */
-        <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
-          {`agama-installer.${arch}-openSUSE.iso`}
-        </a>
-      }
-      <br/>
-      { file ?
-        <a href={`${url}/${file.name}.sha256`}>
-          {`${file.name}.sha256`}
-        </a>
-        :
-        <a href={`${url}/agama-installer.${arch}-openSUSE.iso.sha256`}>
-          {`agama-installer.${arch}-openSUSE.iso.sha256`}
-        </a>
-      }
-    </p>
-  );
-};
-
-export const DownloadLinks = () => {
-  // this variable contains the downloaded data from OBS
-  //   undefined => data not loaded yet (display loading status)
-  //   empty array => download failed or timed out or invalid data was returned
-  //     (display generic unversioned links)
-  const [files, setFiles] = useState();
-
-  // unfortunately the direct download from the download.opensuse.org server does not work because
-  // of the CORS policy, as a workaround use a CORS proxy deployed in the Google Firebase cloud for
-  // downloading the data
-  // see https://github.com/lslezak/cors-proxy/blob/main/functions/index.js
-  // it just forwards the data from
-  // https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso/?jsontable
-  const corsProxy = "https://corsproxy-kcuoblmnuq-uc.a.run.app/";
-
-  const loadData = () => {
-    // if the data is not loaded in 2 seconds then display the generic links
-    const timer = setTimeout(() => !files && setFiles([]), 2000);
-    // download data from the OBS server
-    fetch(corsProxy)
-      .then(response => response.json())
-      .then(json => {
-        // keep only the openSUSE ISO image data, we do not care about the rest
-        const data = json.data.filter(f => f.name.match(/^agama-installer\..*-openSUSE-Build.*\.iso$/))
-        console.log("Downloaded OBS data:", data);
-        setFiles(data);
-      })
-      .catch(err => {
-        console.error("OBS download failed:", err);
-        setFiles([]);
-      })
-      .finally(() => clearTimeout(timer));
-  };
-
-  useEffect(() => {
-    loadData();
-    // refresh every 15 minutes to have up to date links when the page is displayed for a long time
-    const timer = setInterval(() => loadData(), 15*60*1000);
-    return () => clearInterval(timer);
-  }, []);
-
-  return (
-    <>
-      <ArchHeader arch="x86_64" />
-      { files ? <DownloadLink arch="x86_64" files={files}/> : <Loading /> }
-      <ArchHeader arch="aarch64" />
-      { files ? <DownloadLink arch="aarch64" files={files}/> : <Loading /> }
-      <ArchHeader arch="ppc64le" />
-      { files ? <DownloadLink arch="ppc64le" files={files}/> : <Loading /> }
-      <ArchHeader arch="s390x" />
-      { files ? <DownloadLink arch="s390x" files={files}/> : <Loading /> }
-    </>
-  );
-};
 
 # Official Agama Live ISO
 

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -32,14 +32,8 @@ export const DownloadLink = ({arch, files}) => {
 
   return (
     <p>
-      { /* download failed or missing data, display a generic static link without version */ }
-      { !file &&
-        <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
-          {`agama-installer.${arch}-openSUSE.iso`}
-        </a>
-      }
-      { /* found matching image, display the versioned link and the image size */ }
-      { file &&
+      { file ?
+        /* found matching image, display the versioned link and the image size */
         <>
           <a href={`${url}/${file.name}`}>
             {file.name}
@@ -49,16 +43,20 @@ export const DownloadLink = ({arch, files}) => {
           { xbytes(file.size, {fixed: 1}) }
           { ")" }
         </>
-      }
-      <br/>
-      { !file &&
-        <a href={`${url}/agama-installer.${arch}-openSUSE.iso.sha256`}>
-          {`agama-installer.${arch}-openSUSE.iso.sha256`}
+        :
+        /* download failed or missing data, display a generic static link without version */
+        <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
+          {`agama-installer.${arch}-openSUSE.iso`}
         </a>
       }
-      { file &&
+      <br/>
+      { file ?
         <a href={`${url}/${file.name}.sha256`}>
           {`${file.name}.sha256`}
+        </a>
+        :
+        <a href={`${url}/agama-installer.${arch}-openSUSE.iso.sha256`}>
+          {`agama-installer.${arch}-openSUSE.iso.sha256`}
         </a>
       }
     </p>

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -16,6 +16,12 @@ export const HelpLinks = ({ dvdHelp, usbHelp }) => (
   </div>
 );
 
+{/* architecture header */}
+export const ArchHeader = ({arch}) => <h3 id={`download-${arch}`}>{arch}</h3>;
+
+{/* progress indicator */}
+export const Loading = () => <p><em>Loading data...</em></p>;
+
 {/* show a download link for a specified architecture */}
 {/*  arch - the architecture name */}
 {/*  files - data downloaded from OBS */}
@@ -25,49 +31,43 @@ export const DownloadLink = ({arch, files}) => {
   const url = "https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso";
 
   return (
-    <div>
-      <h3 id={`download-${arch}`}>{arch}</h3>
-      <p>
-        { /* no data downloaded yet, display an empty placeholder */ }
-        { !files && <>&nbsp;</> }
-        { /* download failed or missing data, display a generic static link without version */ }
-        { ((files && files.length === 0) || (files && !file)) &&
-          <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
-            {`agama-installer.${arch}-openSUSE.iso`}
+    <p>
+      { /* download failed or missing data, display a generic static link without version */ }
+      { !file &&
+        <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
+          {`agama-installer.${arch}-openSUSE.iso`}
+        </a>
+      }
+      { /* found matching image, display the versioned link and the image size */ }
+      { file &&
+        <>
+          <a href={`${url}/${file.name}`}>
+            {file.name}
           </a>
-        }
-        { /* found matching image, display the versioned link and the image size */ }
-        { file &&
-          <>
-            <a href={`${url}/${file.name}`}>
-              {file.name}
-            </a>
-            { " (" }
-            { /* one decimal place in the formatted size */}
-            { xbytes(file.size, {fixed: 1}) }
-            { ")" }
-          </>
-        }
-        <br/>
-        { !files && <>&nbsp;</> }
-        { ((files && files.length === 0) || (files && !file)) &&
-          <a href={`${url}/agama-installer.${arch}-openSUSE.iso.sha256`}>
-            {`agama-installer.${arch}-openSUSE.iso.sha256`}
-          </a>
-        }
-        { file &&
-          <a href={`${url}/${file.name}.sha256`}>
-            {`${file.name}.sha256`}
-          </a>
-        }
-      </p>
-    </div>
+          { " (" }
+          { /* one decimal place in the formatted size */}
+          { xbytes(file.size, {fixed: 1}) }
+          { ")" }
+        </>
+      }
+      <br/>
+      { !file &&
+        <a href={`${url}/agama-installer.${arch}-openSUSE.iso.sha256`}>
+          {`agama-installer.${arch}-openSUSE.iso.sha256`}
+        </a>
+      }
+      { file &&
+        <a href={`${url}/${file.name}.sha256`}>
+          {`${file.name}.sha256`}
+        </a>
+      }
+    </p>
   );
 };
 
 export const DownloadLinks = () => {
   // this variable contains the downloaded data from OBS
-  //   undefined => data not loaded yet (display empty placeholders)
+  //   undefined => data not loaded yet (display loading status)
   //   empty array => download failed or timed out or invalid data was returned
   //     (display generic unversioned links)
   const [files, setFiles] = useState();
@@ -76,6 +76,8 @@ export const DownloadLinks = () => {
   // of the CORS policy, as a workaround use a CORS proxy deployed in the Google Firebase cloud for
   // downloading the data
   // see https://github.com/lslezak/cors-proxy/blob/main/functions/index.js
+  // it just forwards the data from
+  // https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso/?jsontable
   const corsProxy = "https://corsproxy-kcuoblmnuq-uc.a.run.app/";
 
   const loadData = () => {
@@ -106,10 +108,14 @@ export const DownloadLinks = () => {
 
   return (
     <>
-      <DownloadLink arch={"x86_64"} files={files}/>
-      <DownloadLink arch={"aarch64"} files={files} />
-      <DownloadLink arch={"ppc64le"} files={files} />
-      <DownloadLink arch={"s390x"} files={files} />
+      <ArchHeader arch="x86_64" />
+      { files ? <DownloadLink arch="x86_64" files={files}/> : <Loading /> }
+      <ArchHeader arch="aarch64" />
+      { files ? <DownloadLink arch="aarch64" files={files}/> : <Loading /> }
+      <ArchHeader arch="ppc64le" />
+      { files ? <DownloadLink arch="ppc64le" files={files}/> : <Loading /> }
+      <ArchHeader arch="s390x" />
+      { files ? <DownloadLink arch="s390x" files={files}/> : <Loading /> }
     </>
   );
 };

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -1,23 +1,9 @@
+import React, {useEffect, useState} from "react";
+import xbytes from "xbytes";
+
 import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-
-export const ISOLinks = ({ arch }) => (
-  <div className="flex-container">
-    <Link
-      className="button button--primary"
-      to={`https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso/agama-installer.${arch}-openSUSE.iso`}
-    >
-      ISO
-    </Link>
-    <Link
-      className="button button--secondary"
-      to={`https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso/agama-installer.${arch}-openSUSE.iso.sha256`}
-    >
-      Checksum
-    </Link>
-  </div>
-);
 
 export const HelpLinks = ({ dvdHelp, usbHelp }) => (
   <div className="flex-container">
@@ -30,32 +16,121 @@ export const HelpLinks = ({ dvdHelp, usbHelp }) => (
   </div>
 );
 
+{/* show a download link for a specified architecture */}
+{/*  arch - the architecture name */}
+{/*  files - data downloaded from OBS */}
+export const DownloadLink = ({arch, files}) => {
+  const file = files?.find(f => f.name.includes(arch));
+  // base URL where the images are located
+  const url = "https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso";
+
+  return (
+    <div>
+      <h3 id={`download-${arch}`}>{arch}</h3>
+      <p>
+        { /* no data downloaded yet, display an empty placeholder */ }
+        { !files && <>&nbsp;</> }
+        { /* download failed or missing data, display a generic static link without version */ }
+        { ((files && files.length === 0) || (files && !file)) &&
+          <a href={`${url}/agama-installer.${arch}-openSUSE.iso`}>
+            {`agama-installer.${arch}-openSUSE.iso`}
+          </a>
+        }
+        { /* found matching image, display the versioned link and the image size */ }
+        { file &&
+          <>
+            <a href={`${url}/${file.name}`}>
+              {file.name}
+            </a>
+            { " (" }
+            { /* one decimal place in the formatted size */}
+            { xbytes(file.size, {fixed: 1}) }
+            { ")" }
+          </>
+        }
+        <br/>
+        { !files && <>&nbsp;</> }
+        { ((files && files.length === 0) || (files && !file)) &&
+          <a href={`${url}/agama-installer.${arch}-openSUSE.iso.sha256`}>
+            {`agama-installer.${arch}-openSUSE.iso.sha256`}
+          </a>
+        }
+        { file &&
+          <a href={`${url}/${file.name}.sha256`}>
+            {`${file.name}.sha256`}
+          </a>
+        }
+      </p>
+    </div>
+  );
+};
+
+export const DownloadLinks = () => {
+  // this variable contains the downloaded data from OBS
+  //   undefined => data not loaded yet (display empty placeholders)
+  //   empty array => download failed or timed out or invalid data was returned
+  //     (display generic unversioned links)
+  const [files, setFiles] = useState();
+
+  // unfortunately the direct download from the download.opensuse.org server does not work because
+  // of the CORS policy, as a workaround use a CORS proxy deployed in the Google Firebase cloud for
+  // downloading the data
+  // see https://github.com/lslezak/cors-proxy/blob/main/functions/index.js
+  const corsProxy = "https://corsproxy-kcuoblmnuq-uc.a.run.app/";
+
+  const loadData = () => {
+    // if the data is not loaded in 2 seconds then display the generic links
+    const timer = setTimeout(() => !files && setFiles([]), 2000);
+    // download data from the OBS server
+    fetch(corsProxy)
+      .then(response => response.json())
+      .then(json => {
+        // keep only the openSUSE ISO image data, we do not care about the rest
+        const data = json.data.filter(f => f.name.match(/^agama-installer\..*-openSUSE-Build.*\.iso$/))
+        console.log("Downloaded OBS data:", data);
+        setFiles(data);
+      })
+      .catch(err => {
+        console.error("OBS download failed:", err);
+        setFiles([]);
+      })
+      .finally(() => clearTimeout(timer));
+  };
+
+  useEffect(() => {
+    loadData();
+    // refresh every 15 minutes to have up to date links when the page is displayed for a long time
+    const timer = setInterval(() => loadData(), 15*60*1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <>
+      <DownloadLink arch={"x86_64"} files={files}/>
+      <DownloadLink arch={"aarch64"} files={files} />
+      <DownloadLink arch={"ppc64le"} files={files} />
+      <DownloadLink arch={"s390x"} files={files} />
+    </>
+  );
+};
+
 # Official Agama Live ISO
 
 Agama **is a multi-product installer**. It means that you can install different distributions using
 a single medium. In close collaboration with the openSUSE project, the current image allows
 installing [openSUSE Tumbleweed](https://www.opensuse.org/#Tumbleweed), [openSUSE Leap 16.0
-Alpha](https://www.opensuse.org/#Leap), [openSUSE Micro OS](https://get.opensuse.org/microos/) and
+](https://www.opensuse.org/#Leap), [openSUSE Micro OS](https://get.opensuse.org/microos/) and
 [openSUSE Slowroll](https://en.opensuse.org/Portal:Slowroll) (experimental).
 
 ## Download the Agama Live ISO
 
-The first step is to download the ISO image that matches your architecture.
+Download the ISO image that matches the architecture of your machine. The `*.sha256` files contain a
+checksum of the ISO file so you can verify that the image was downloaded correctly, see the
+instructions below.
 
-<Tabs className="unique-tabs">
-  <TabItem value="x86_64" label="x86_64" default>
-    <ISOLinks arch="x86_64" />
-  </TabItem>
-  <TabItem value="aarch64" label="aarch64">
-    <ISOLinks arch="aarch64" />
-  </TabItem>
-  <TabItem value="ppc64le" label="ppc64le">
-    <ISOLinks arch="ppc64le" />
-  </TabItem>
-  <TabItem value="s390x" label="s390x">
-    <ISOLinks arch="s390x" />
-  </TabItem>
-</Tabs>
+<DownloadLinks />
+
+### Verifying the downloaded image
 
 You might want to check whether the ISO was correctly downloaded. If that's the case, you can
 download the checksum file too and use the
@@ -65,7 +140,7 @@ download the checksum file too and use the
 sha256sum -c agama-installer.x86_64-openSUSE.iso.sha256
 ```
 
-Obviously, use the checksum that correponds with the downloaded ISO.
+Obviously, use the checksum that corresponds to the downloaded ISO.
 
 ## Create a bootable medium
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10417,6 +10417,11 @@ ws@^8.13.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
+xbytes@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/xbytes/-/xbytes-1.9.1.tgz#0a6a883205257a3fb747ef7cf45f52f8fc770523"
+  integrity sha512-29E0ygMFWrM5JW2W1ypmezjyR2FOS5aCszdLe620ymSJBoZzL0/RCLJKCoUFu3DfQGhZ/FWykEBp5dfEy6+hjA==
+
 xdg-basedir@^5.0.1, xdg-basedir@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-5.1.0.tgz#1efba19425e73be1bc6f2a6ceb52a3d2c884c0c9"


### PR DESCRIPTION
## Problem

- The download links UI is a bit strange, it is not obvious that the architecture names switch the download link
- It's not clean what it will actually download
- The link points to a static image name without version (`agama-installer.<arch>-openSUSE.iso`) so you do not know which version you downloaded. And if you download the image later again you can easily overwrite the old file.
- The ISO images are quite large, user does not know the size until the download starts
- Related problem: https://github.com/agama-project/agama-project.github.io/issues/37

The current download section:
<img width="556" height="224" alt="image" src="https://github.com/user-attachments/assets/ae7d924f-2402-4e4c-af98-f752c0380210" />

## Solution

- Download the current data directly from OBS. Fortunately [OBS provides JSON data](https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/images/iso/?jsontable), unfortunately they cannot be used directly because of the CORS limitation. :worried:  See the workaround below.
- Display versioned links, show the ISO image size
- See the [rendered preview](https://agama-preview-pull-103.surge.sh/download)

Change in this pull request:
<img width="835" height="578" alt="image" src="https://github.com/user-attachments/assets/ed4d1b37-e723-40ee-9efb-aa0b49b08321" />


## Details

- To avoid flashing and resizing UI initially only empty placeholders are displayed.
- After downloading the data the empty placeholders are replaced with correct links.
- If the download fails or data is missing then the unversioned static links are displayed.
- Also when the download takes more than 2 seconds it displays the static links so the user is still able to download the images. When the download finishes later the static links are replaced with the current links.
- The data is refreshed every 15 minutes to have up to date links when the page is displayed for a long time

Fallback with static links:
<img width="835" height="578" alt="image" src="https://github.com/user-attachments/assets/f7c7aaf5-f48d-4657-9e2c-e8c528c70352" />


## CORS proxy

- Because the direct download from OBS is blocked by a CORS policy we need to use a workaround, a CORS proxy.
- There are some free CORS proxies available but some require registration or have limited usage or do not look reliable
- It turned out that running own CORS proxy is simple ([article1](https://medium.com/@kotharipujan123/how-i-cut-costs-for-cors-proxy-by-building-with-google-cloud-function-instead-of-using-a-paid-proxy-acc1995e373f) and [article2](https://keepdeploying.com/how-to-create-a-cors-proxy-server-with-firebase-functions-f4be840026b5)) so I implemented a [trivial OBS CORS proxy](https://github.com/lslezak/cors-proxy/blob/main/functions/index.js) and deployed it to Firebase (available at https://corsproxy-kcuoblmnuq-uc.a.run.app).