### PR TITLE
Update download.mdx

### DIFF
--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -34,9 +34,9 @@ export const HelpLinks = ({ dvdHelp, usbHelp }) => (
 
 Agama **is a multi-product installer**. It means that you can install different distributions using
 a single medium. In close collaboration with the openSUSE project, the current image allows
-installing [openSUSE Tumbleweed](https://www.opensuse.org/#Tumbleweed), [openSUSE Leap 16.0
-Alpha](https://www.opensuse.org/#Leap), [openSUSE Micro OS](https://get.opensuse.org/microos/) and
-[openSUSE Slowroll](https://en.opensuse.org/Portal:Slowroll) (experimental).
+installing [Tumbleweed](https://www.opensuse.org/#Tumbleweed), [Leap 16.0
+Beta](https://get.opensuse.org/leap/16.0/), [MicroOS](https://get.opensuse.org/microos/), [Leap Micro 6.2 Beta](https://en.opensuse.org/Portal:Leap_Micro), [Kalpa](www.kalpadesktop.org), and
+[Slowroll](https://en.opensuse.org/Portal:Slowroll).
 
 ## Download the Agama Live ISO
 


### PR DESCRIPTION
+ Added Leap Micro 6.2 Beta to listed product offering
+ Added Link to Leap Micro wiki Article (get-o-o doesnt have LM6.2 Page as of 7/28/25)
+ Added Kalpa to listed product offering
+ Linked Kalpa to kalpadesktop.org (maintained by Kalpa Lead Dev SFaulken since Kalpa does not have a get-o-o page as of 7/28/25)
+ Renamed Leap 16.0 Alpha to Beta (refered to as Beta on get-o-o page and Agama Product Selection Screen)
+ Redirected Link from get.opensuse.org/#Leap to get.opensuse.org/leap/16.0
+ Corrected formatting of the name MicroOS from Micro OS (used get-o-o as reference)

- Removed project prefix from listed Product Lineup [e.g. openSUSE Slowroll -> Slowroll] to create uniformity, very rarely have i seen the project prefix used in most instances and in Branding guidelines for certain projects like Kalpa (https://kalpadesktop.org/documentation/brandguide/) it requests that it not use the project prefix

Please let me know if there are any questions, comments or concerns

Best, phantasNick