### PR TITLE
Update Roadmap to versions 17 and 18

### DIFF
--- a/about/roadmap.md
+++ b/about/roadmap.md
@@ -7,49 +7,31 @@ sidebar_position: 3
 Agama is a project under constant development and priorities are re-evaluated every few weeks. This
 page offers an overview on the current state of the ever-changing development plans.
 
-## Agama 16 (latest released version)
+## Agama 17 (latest released version)
 
-- Use Wayland instead of X11 at Agama-live (the default installation media).
-- Support in the web interface to install over existing software RAIDs.
-- Improve the possibilities to patch the installer and the installation media.
-- Reorganize the commands `config` and `profile` at the command-line interface.
-- Report the installation status via
-  [IPMI](https://en.wikipedia.org/wiki/Intelligent_Platform_Management_Interface).
-- Improve error reporting on registration.
-- Visible conflict resolution for patterns.
-- Passwords strength check.
-- Notify the machine is rebooting to remote browsers.
-- Improvements in the user interface for network configuration.
-    - Associate connections to a given MAC address.
-    - Configure persistent vs non-persistent connections.
-- Enhancements at config-based (unattended) installation.
-    - Option to not install recommended packages.
-    - Possibility to extend the installation with user-defined repositories.
-    - Use sorting as part of the criteria to match storage devices
-
-## Agama 17 (~ July 21st)
-
-- Even more possibilities to patch the installer and the installation media.
-- Polish the Wayland-based Live image.
-- Support the new libzypp singletrans feature.
-- Web-based graphical user interface.
+- More possibilities to patch the installer and the installation media.
+- Allow to de-select the default LSM (eg. SElinux).
+- Web-based graphical user interface:
     - Define the URL of the RMT server.
     - Possibility to directly use a disk without partitions.
-- Unattended installation.
+    - Usability improvements managing the storage configuration.
+- Unattended installation:
     - Support to configure zFCP disks.
-    - Explicit support in the profile to enable (or not) multipath.
+    - Configuration of VLAN.
     - Proper error reporting when the given profile is not found.
 
 ## Agama 18 (~ August 18th)
 
 - Stabilization release: mainly bug fixes and documentation.
-- Unattended installation
-    - Improve matching and sorting of storage devices.
-    - Re-evaluate the current concept of installer "questions" and the mechanisms to answer them.
+- Make "boot from hard disk" the default option at the Agama Live ISO.
+- Ability to validate a JSON profile locally (no Agama instance running).
+- Alert the user when the storage web user interface needs a refresh.
+- Unattended installation:
+    - Managing questions directly from the Agama profile.
+    - Allow to add and remove patterns to install, in addition to replacing the full list.
 
 ## Mid term plans (end of 2025)
 
-- Welcome screen for local installation.
 - Ability to adjust some simple settings related to security.
 - Basic management of Kdump configuration.
 - Deal with multiple real-time clocks.
@@ -68,6 +50,7 @@ page offers an overview on the current state of the ever-changing development pl
 
 ## Long term plans (during 2026)
 
+- Welcome screen for local installation.
 - Introduce the concept of security profiles.
 - Extend the "Storage" section of the user interface.
   - Management of MD RAID devices.


### PR DESCRIPTION
I will not have time to write the Agama 17 blog post this week. This PR at least updates the roadmap (something we usually do when publishing a new blog post).

See [the preview](https://agama-preview-pull-110.surge.sh/about/roadmap).