### PR TITLE
The 'inst.listen_on' boot option has been replaced by 'inst.remote'

### DIFF
--- a/docs/user/reference/boot_options/index.mdx
+++ b/docs/user/reference/boot_options/index.mdx
@@ -174,22 +174,10 @@ options at the end of the `linux` line.
   live.password_systemd=1
   ```
 
-- `inst.listen_on`: <Since version="16.1"/> By default the Agama installer can be accessed using all
-  network interfaces present in the machine. But for increased security it is possible to limit
-  access only to particular network interfaces or it is possible to completely disable remote
-  access.
-  - `inst.listen_on=localhost` - listen only on loop back (localhost) device. This disables remote
-    access, the Agama installer can be accessed only locally.
-  - `inst.listen_on=<ip>` - listen on the specified IP address. Both IPv4 and IPv6 addresses are
-    supported. It is possible to use multiple IP addresses separated by comma. Addresses not
-    matching any network interface in the system are ignored.
-  - `inst.listen_on=<interface>` - listen on the specified network interface. Multiple interfaces
-    can be separated by comma, not found interfaces are ignored. Example: `inst.listen_on=eth2`
-  - `inst.listen_on=all` - listen on all network interfaces (allow local and remote access). This is
-    the default behavior, added just for completeness.
-
-  The Agama installer can be always accessed locally, even in cases when specifying an IP address or
-  an network interface.
+- `inst.remote`: <Since version="16.1"/> By default the Agama installer can be accessed remotely
+  from other machines or mobile devices. For increased security it is possible to disable the remote
+  access with the `inst.remote=0` boot option. Then the installer can be accessed only locally from
+  the machine itself.
 
   Note: For disabling other network services (like SSH) use the standard `systemd.mask` boot option,
   see more details below.


### PR DESCRIPTION
- Related to https://github.com/agama-project/agama/pull/3336