### PR TITLE
Document systemd-boot preview and encryption methods

### DIFF
--- a/docs/user/reference/boot_options/index.mdx
+++ b/docs/user/reference/boot_options/index.mdx
@@ -132,7 +132,9 @@ options at the end of the `linux` line.
 
   This is a preview feature for testing systemd-boot support. It will automatically fall back to
   using grub2 bootloader if the system does not meet
-  [BLS requirements](https://uapi-group.org/specifications/specs/boot_loader_specification/).
+  [BLS requirements](https://uapi-group.org/specifications/specs/boot_loader_specification/). This
+  option may disappear in the future, after finishing the testing period for the systemd-boot
+  support.
 
   :::
 

--- a/docs/user/reference/boot_options/index.mdx
+++ b/docs/user/reference/boot_options/index.mdx
@@ -125,6 +125,17 @@ options at the end of the `linux` line.
   libzypp in the `/var/log/YaST2/autoTestcase` directory and the `inst.solver_testcase` option is
   ignored.
 
+- `inst.systemd_boot_preview=1`: <Since version="16.1"/> Enables the systemd-boot bootloader as a
+  preview feature.
+
+  :::note
+
+  This is a preview feature for testing systemd-boot support. It will automatically fall back to
+  using grub2 bootloader if the system does not meet
+  [BLS requirements](https://uapi-group.org/specifications/specs/boot_loader_specification/).
+
+  :::
+
 - `inst.install`: on unattended mode, Agama automatically starts the installation after reading the
   profile. However, if you set `inst.install` to `0`, Agama stops after reading the configuration,
   giving the user a chance to review the installation options before proceeding.

--- a/docs/user/reference/profile/storage.md
+++ b/docs/user/reference/profile/storage.md
@@ -859,12 +859,15 @@ Properties:
   `argon2i`, `argon2id`.
 - `label` (optional): LUKS2 label for the encrypted device.
 - `tpm` (optional): <Since version="16.1"/> Whether to use TPM2 (Trusted Platform Module 2.0) for
-  unlocking. Default is `false`.
+  automatically unlocking the device during system boot. Default is `false`.
 
 ### Pervasive LUKS2 Encryption
 
-Pervasive encryption is a specialized form of LUKS2 encryption available on IBM Z mainframe systems,
-which uses hardware-based encryption capabilities.
+Pervasive encryption is a specialized form of LUKS2 encryption available on IBM Z mainframe systems.
+It encrypts the device using LUKS2 with a master secure key processed by a Crypto Express
+cryptographic coprocessor. The encryption password is used to protect the access to the master key.
+If there are several APQNs (Adjunct Processor Queue Number) in the system, you can select which ones
+to use.
 
 ```json
 "encryption": {
@@ -898,11 +901,18 @@ This encryption method is deprecated. Use LUKS2 with the `tpm` option set to `tr
 
 For swap devices, Agama provides simplified encryption options that are suitable for swap space:
 
-- `randomSwap`: Encrypts swap with a random key generated at boot. No password required. Data is
-  lost on reboot.
-- `protectedSwap`: Encrypts swap using a key derived from the system. Provides protection while the
-  system is powered off.
-- `secureSwap`: Similar to protected swap with additional security measures.
+- `randomSwap`: uses a randomly generated key at boot and Hibernation to hard disk is not supported.
+  The swap device is re-encrypted during every boot, and its previous content is destroyed. You
+  should disable Hibernation to avoid Data Loss! Please, only use encryption with volatile keys if
+  you are sure about the implications.
+
+- `protectedSwap`: uses a volatile protected AES key (without requiring a cryptographic
+  co-processor) to encrypt a swap device. This is an improvement over randomSwap method and all
+  considerations for such method still apply.
+
+- `secureSwap`: encryption available on IBM Z mainframe systems. It uses a volatile secure AES key
+  (generated from a cryptographic co-processor) for encrypting a swap device. This is an improvement
+  over randomSwap method and all considerations for such method still apply.
 
 ```json
 "encryption": "randomSwap"
@@ -913,7 +923,7 @@ camelCase instead.
 
 ### Complete Encryption Examples
 
-#### Encrypted Partition with LUKS2
+#### Encrypted Partitions with LUKS2
 
 ```json
 "storage": {
@@ -932,6 +942,10 @@ camelCase instead.
             "path": "/",
             "type": "ext4"
           }
+        },
+        {
+          "encryption": "randomSwap",
+          "filesystem": { "path": "swap" }
         }
       ]
     }
@@ -973,8 +987,7 @@ camelCase instead.
         {
           "name": "swap",
           "size": "2 GiB",
-          "encryption": "randomSwap",
-          "filesystem": { "path": "swap", "type": "swap" }
+          "filesystem": { "path": "swap" }
         }
       ]
     }

--- a/docs/user/reference/profile/storage.md
+++ b/docs/user/reference/profile/storage.md
@@ -2,6 +2,8 @@
 sidebar_position: 8
 ---
 
+import { Since } from "@site/src/components/Badge";
+
 # Storage
 
 The general concepts regarding configuration of storage devices with Agama are exposed at the
@@ -796,6 +798,183 @@ the _generate_ section:
               "luks2": { "password": "12345" }
             }
           }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Encryption Options
+
+Agama supports encrypting drives, partitions, MD RAIDs, and logical volumes using various encryption
+methods. The encryption configuration is specified using an `encryption` property within the device
+definition.
+
+### LUKS1 Encryption
+
+LUKS1 (Linux Unified Key Setup version 1) is the legacy encryption format. It is recommended to use
+LUKS2 for new installations unless compatibility with older systems is required.
+
+```json
+"encryption": {
+  "luks1": {
+    "password": "my secret passphrase",
+    "cipher": "aes-xts-plain64",
+    "keySize": 256
+  }
+}
+```
+
+Properties:
+
+- `password` (required): Password to use when creating the encryption device.
+- `cipher` (optional): Encryption cipher compatible with cryptsetup's `--cipher` argument.
+- `keySize` (optional): Key size in bits. Must be a multiple of 8 and compatible with the cipher.
+
+### LUKS2 Encryption
+
+LUKS2 is the current standard for disk encryption in Linux, offering improved security and
+flexibility over LUKS1.
+
+```json
+"encryption": {
+  "luks2": {
+    "password": "my secret passphrase",
+    "cipher": "aes-xts-plain64",
+    "keySize": 512,
+    "pbkdFunction": "argon2id",
+    "label": "encrypted_root",
+    "tpm": true
+  }
+}
+```
+
+Properties:
+
+- `password` (required): Password to use when creating the encryption device.
+- `cipher` (optional): Encryption cipher compatible with cryptsetup's `--cipher` argument.
+- `keySize` (optional): Key size in bits. Must be a multiple of 8 and compatible with the cipher.
+- `pbkdFunction` (optional): Password-Based Key Derivation Function. Possible values: `pbkdf2`,
+  `argon2i`, `argon2id`.
+- `label` (optional): LUKS2 label for the encrypted device.
+- `tpm` (optional): <Since version="16.1"/> Whether to use TPM2 (Trusted Platform Module 2.0) for
+  unlocking. Default is `false`.
+
+### Pervasive LUKS2 Encryption
+
+Pervasive encryption is a specialized form of LUKS2 encryption available on IBM Z mainframe systems,
+which uses hardware-based encryption capabilities.
+
+```json
+"encryption": {
+  "pervasiveLuks2": {
+    "password": "my secret passphrase"
+  }
+}
+```
+
+Properties:
+
+- `password` (required): Password to use when creating the encryption device.
+
+### TPM-Based Full Disk Encryption
+
+:::warning[Deprecated]
+
+This encryption method is deprecated. Use LUKS2 with the `tpm` option set to `true` instead.
+
+:::
+
+```json
+"encryption": {
+  "tpmFde": {
+    "password": "my secret passphrase"
+  }
+}
+```
+
+### Swap Encryption
+
+For swap devices, Agama provides simplified encryption options that are suitable for swap space:
+
+- `randomSwap`: Encrypts swap with a random key generated at boot. No password required. Data is
+  lost on reboot.
+- `protectedSwap`: Encrypts swap using a key derived from the system. Provides protection while the
+  system is powered off.
+- `secureSwap`: Similar to protected swap with additional security measures.
+
+```json
+"encryption": "randomSwap"
+```
+
+Note: The snake_case variants (`random_swap`, `protected_swap`, `secure_swap`) are deprecated. Use
+camelCase instead.
+
+### Complete Encryption Examples
+
+#### Encrypted Partition with LUKS2
+
+```json
+"storage": {
+  "drives": [
+    {
+      "partitions": [
+        {
+          "size": "100 GiB",
+          "encryption": {
+            "luks2": {
+              "password": "my secret passphrase",
+              "label": "root_crypt"
+            }
+          },
+          "filesystem": {
+            "path": "/",
+            "type": "ext4"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Encrypted LVM Setup
+
+```json
+"storage": {
+  "drives": [
+    {
+      "partitions": [
+        {
+          "alias": "pv",
+          "id": "lvm",
+          "size": { "min": "50 GiB" },
+          "encryption": {
+            "luks2": {
+              "password": "my secret passphrase",
+              "tpm": true
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "volumeGroups": [
+    {
+      "name": "system",
+      "physicalVolumes": ["pv"],
+      "logicalVolumes": [
+        {
+          "name": "root",
+          "size": { "min": "30 GiB" },
+          "filesystem": { "path": "/", "type": "btrfs" }
+        },
+        {
+          "name": "swap",
+          "size": "2 GiB",
+          "encryption": "randomSwap",
+          "filesystem": { "path": "swap", "type": "swap" }
         }
       ]
     }

--- a/docs/user/reference/profile/storage.md
+++ b/docs/user/reference/profile/storage.md
@@ -828,7 +828,7 @@ LUKS2 for new installations unless compatibility with older systems is required.
 
 Properties:
 
-- `password` (required): Password to use when creating the encryption device.
+- `password` (required): Encryption passphrase used to open the device.
 - `cipher` (optional): Encryption cipher compatible with cryptsetup's `--cipher` argument.
 - `keySize` (optional): Key size in bits. Must be a multiple of 8 and compatible with the cipher.
 
@@ -852,7 +852,7 @@ flexibility over LUKS1.
 
 Properties:
 
-- `password` (required): Password to use when creating the encryption device.
+- `password` (required): Encryption passphrase used to open the device.
 - `cipher` (optional): Encryption cipher compatible with cryptsetup's `--cipher` argument.
 - `keySize` (optional): Key size in bits. Must be a multiple of 8 and compatible with the cipher.
 - `pbkdFunction` (optional): Password-Based Key Derivation Function. Possible values: `pbkdf2`,
@@ -879,12 +879,15 @@ cryptographic coprocessor. The encryption password is used to protect the access
 
 Properties:
 
-- `password` (required): Password to use when creating the encryption device.
+- `password` (required): Encryption passphrase used to protect the access to the master key.
 - `apqns` (optional): List of APQNs (Adjunct Processor Queue Numbers) used to generate secure keys.
-  Each APQN is specified as a string (e.g., `"01.0001"`). If not specified, Agama will use the
-  available APQNs in the system.
-- `keyType` (optional): Type of the generated secure key. Possible values: `EP11-AES`,
-  `CCA-AESCIPHER`, `CCA-AESDATA`.
+  Each APQN is specified as a string (e.g., `"01.0001"`). All the APQNs used for generating the
+  secure key must have the same master key. If not specified, all online APQNs in the system will be
+  used.
+- `keyType` (optional): Type of the generated secure key. When using EP11 APQNs, the only supported
+  key type is `EP11-AES`. When using CCA APQNs, the key types `CCA-AESCIPHER` and `CCA-AESDATA` can
+  be used. If the key type is not specified, it will be automatically chosen based on the used
+  APQNs.
 
 ### TPM-Based Full Disk Encryption
 
@@ -904,7 +907,7 @@ This encryption method is deprecated. Use LUKS2 with the `tpm` option set to `tr
 
 ### Swap Encryption
 
-For swap devices, Agama provides simplified encryption options that are suitable for swap space:
+Agama provides specific encryption options for swap space:
 
 - `randomSwap`: uses a randomly generated key at boot and Hibernation to hard disk is not supported.
   The swap device is re-encrypted during every boot, and its previous content is destroyed. You

--- a/docs/user/reference/profile/storage.md
+++ b/docs/user/reference/profile/storage.md
@@ -866,13 +866,13 @@ Properties:
 Pervasive encryption is a specialized form of LUKS2 encryption available on IBM Z mainframe systems.
 It encrypts the device using LUKS2 with a master secure key processed by a Crypto Express
 cryptographic coprocessor. The encryption password is used to protect the access to the master key.
-If there are several APQNs (Adjunct Processor Queue Number) in the system, you can select which ones
-to use.
 
 ```json
 "encryption": {
   "pervasiveLuks2": {
-    "password": "my secret passphrase"
+    "password": "my secret passphrase",
+    "apqns": ["01.0001", "01.0002"],
+    "keyType": "CCA-AESDATA"
   }
 }
 ```
@@ -880,6 +880,11 @@ to use.
 Properties:
 
 - `password` (required): Password to use when creating the encryption device.
+- `apqns` (optional): List of APQNs (Adjunct Processor Queue Numbers) used to generate secure keys.
+  Each APQN is specified as a string (e.g., `"01.0001"`). If not specified, Agama will use the
+  available APQNs in the system.
+- `keyType` (optional): Type of the generated secure key. Possible values: `EP11-AES`,
+  `CCA-AESCIPHER`, `CCA-AESDATA`.
 
 ### TPM-Based Full Disk Encryption
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -167,11 +167,8 @@ const config: Config = {
 
   markdown: {
     mermaid: true,
-    hooks: {
-      onBrokenMarkdownLinks: "throw",
-      onBrokenMarkdownImages: "throw",
-    }
   },
+  onBrokenMarkdownLinks: "throw",
   themes: ["@docusaurus/theme-mermaid"],
   plugins: [
     // zoom images on click
@@ -188,7 +185,7 @@ const config: Config = {
         path: 'about',
         routeBasePath: 'about',
         sidebarPath: './sidebarsAbout.js',
-      } satisfies DocsOptions,
+      },
     ]
   ],
 };


### PR DESCRIPTION
* Adapt config to v3.
* Added documentation for the `inst.systemd_boot_preview` boot option.
* Added a comprehensive "Encryption Options" section to the storage documentation.