### PR TITLE
Add NTP documentation

### DIFF
--- a/docs/user/reference/autoyast.md
+++ b/docs/user/reference/autoyast.md
@@ -1,4 +1,4 @@
-# AutoYaST compatibility
+# AutoYaST compatibility reference
 
 Let's describe which sections and elements from an AutoYaST profile are (or will be) supported in
 Agama. In some cases, you might find a table with the following columns:
@@ -12,19 +12,39 @@ Agama. In some cases, you might find a table with the following columns:
 - Agama: name of the Agama element.
 - Comment: any comment or reason about the element.
 
-:::warning
-
-AutoYaST support is not fully defined yet, which means that we might add support for more sections
-in the future even if we do not plan to do so now. However, we will do our best to keep this
-document up to date.
-
-Please, let us know if you miss support for any section.
-
-:::
-
 ## add-on
 
-There are plans to support this section in the future.
+This section is supported.
+
+### add-on/add_on_products
+
+This section is supported.
+
+| AutoYaST          | Supported | Agama        | Notes |
+| ----------------- | --------- | ------------ | ----- |
+| `media_url`       | yes       | `url`        |       |
+| `product_dir`     | yes       | `productDir` |       |
+| `product`         | no        |              |       |
+| `alias`           | yes       |              |       |
+| `priority`        | yes       |              |       |
+| `ask_on_error`    | no        |              |       |
+| `confirm_license` | no        |              |       |
+| `name`            | yes       |              |       |
+
+### add-on/add_on_others
+
+This section is supported.
+
+| AutoYaST          | Supported | Agama        | Notes |
+| ----------------- | --------- | ------------ | ----- |
+| `media_url`       | yes       | `url`        |       |
+| `product_dir`     | yes       | `productDir` |       |
+| `product`         | no        |              |       |
+| `alias`           | yes       |              |       |
+| `priority`        | yes       |              |       |
+| `ask_on_error`    | no        |              |       |
+| `confirm_license` | no        |              |       |
+| `name`            | yes       |              |       |
 
 ## bootloader
 
@@ -64,6 +84,17 @@ This section is supported.
 | `xen_append`        | no        |                                |       |
 | `xen_kernel_append` | no        |                                |       |
 
+## dasd
+
+This section is supported.
+
+| AutoYaST   | Supported | Agama | Notes |
+| ---------- | --------- | ----- | ----- |
+| `device`   | no        |       |       |
+| `dev_name` | no        |       |       |
+| `channel`  | yes       |       |       |
+| `diag`     | yes       |       |       |
+
 ## files
 
 This section is supported.
@@ -79,7 +110,24 @@ This section is supported.
 
 ## iscsi-client
 
-There are plans to support this section in the future.
+This section is supported.
+
+| AutoYaST        | Supported | Agama             | Notes |
+| --------------- | --------- | ----------------- | ----- |
+| `initiatorname` | yes       | `iscsi.initiator` |       |
+| `version`       | no        |                   |       |
+
+### iscsi-client/targets[]
+
+This section is supported.
+
+| AutoYaST     | Supported | Agama                       | Notes                                       |
+| ------------ | --------- | --------------------------- | ------------------------------------------- |
+| `authmethod` | no        |                             |                                             |
+| `portal`     | yes       | `iscsi.targets[].address`   | Splitted into two values, address and port. |
+| `startup`    | yes       |                             |                                             |
+| `target`     | yes       | `iscsi.targets[].name`      |                                             |
+| `iface`      | yes       | `iscsi.targets[].interface` |                                             |
 
 ## kdump
 
@@ -214,6 +262,25 @@ same.
 | `wireless_wpa_identity`        | no        |                                      |                                                  |
 | `wireless_wpa_password`        | yes       | `password`                           |                                                  |
 | `wireless_wpa_psk`             | yes       | `password`                           |                                                  |
+
+## ntp-client
+
+This section is supported.
+
+| AutoYaST     | Supported | Agama | Notes |
+| ------------ | --------- | ----- | ----- |
+| `ntp_policy` | no        |       |       |
+| `ntp_sync`   | no        |       |       |
+
+### ntp-client/ntp_servers[]
+
+This section is supported. All servers are considered of type "pool"
+
+| AutoYaST  | Supported | Agama                   | Notes |
+| --------- | --------- | ----------------------- | ----- |
+| `address` | yes       | `ntp.sources[].address` |       |
+| `iburst`  | yes       | `ntp.sources[].iburst`  |       |
+| `offline` | yes       | `ntp.sources[].offline` |       |
 
 ## proxy
 
@@ -363,7 +430,7 @@ This section is supported.
 | `email`                            | yes       | `product.registrationEmail`              |                                                                          |
 | `install_updates`                  | no        |                                          |                                                                          |
 | `reg_code`                         | yes       | `product.registrationCode`               |                                                                          |
-| `reg_server`                       | planned   |                                          |                                                                          |
+| `reg_server`                       | yes       | `product.registrationUrl`                |                                                                          |
 | `reg_server_cert`                  | no        |                                          |                                                                          |
 | `reg_server_cert_fingerprint`      | yes       | `security.sslCertificates[].fingerprint` |                                                                          |
 | `reg_server_cert_fingerprint_type` | yes       | `security.sslCertificates[].algorithm`   |                                                                          |
@@ -389,7 +456,11 @@ This section is supported. Only the root and the first user are considered.
 | `fullName`        | yes       | `user.fullName`       |                                                                |
 | `password`        | yes       | `user.password`       |                                                                |
 | `encrypted`       | yes       | `user.hashedPassword` | If set to true, it uses "hashedPassword" instead of "password" |
-| `authorized_keys` | yes       | `root.sshPublicKey`   |                                                                |
+| `authorized_keys` | yes       | `root.sshPublicKeys`  |                                                                |
+
+## zfcp
+
+This section is supported.
 
 ## Unsupported sections
 
@@ -413,7 +484,6 @@ The following sections are not supported and there are no plans to support them 
 - `nfs_server`
 - `nis`
 - `nis_server`
-- `ntp-client`
 - `printer`
 - `report`
 - `samba-client`

--- a/docs/user/reference/boot_options/index.mdx
+++ b/docs/user/reference/boot_options/index.mdx
@@ -189,6 +189,15 @@ options at the end of the `linux` line.
   proxy=http://192.168.122.1:3128
   ```
 
+- `rd.ntp`: sets the time sources to synchronize the date/time. You can specify multiple time
+  sources by using this option several times. The installation media will try to synchronize the
+  date/time while booting, before Agama starts. The given configuration will be copied by Agama to
+  the installed system.
+
+  ```text
+  rd.ntp=pool:1.opensuse.pool.ntp.org:iburst
+  ```
+
 - `systemd.unit`: standard way to change target for systemd boot. It is useful for head-less mode
   when graphical interface neither browser needs to be started locally.
 

--- a/docs/user/reference/profile/ntp.md
+++ b/docs/user/reference/profile/ntp.md
@@ -1,0 +1,48 @@
+# Network Time Protocol (NTP)
+
+It is crucial that the system you are installing has the right date and time. Otherwise, you can
+face some weird errors during the installation. And that's where the Network Time Protocol (NTP)
+comes in.
+
+The Agama installation medium ships [chrony](https://chrony-project.org/), which will synchronize
+the system date and time automatically so you do not need to care about it. However, there are some
+situations where you might want to force Agama to use a specific NTP server.
+
+The configuration file might include an `ntp` section where you can define a list of time sources to
+use. If that list if given, Agama will force `chrony` to synchronize using those sources and it will
+copy the configuration to the installed system.
+
+```json
+{
+  "ntp": {
+    "sources": [
+      {
+        "type": "pool",
+        "address": "2.opensuse.pool.ntp.org",
+        "iburst": true,
+        "offline": false
+      }
+    ]
+  }
+}
+```
+
+The `ntp` section includes a list of `sources` to define the systems to synchronize with. Each
+source can specify:
+
+- `address`: the hostname or IP address of the NTP source.
+- `type`: the type of NTP source. It may use:
+  - `pool`: a pool of NTP servers (e.g., `pool.ntp.org`). The pool name will be resolved to multiple
+    servers and chrony will use the best ones.
+  - `server`: a specific NTP server to synchronize time from.
+  - `peer`: an NTP peer for symmetric synchronization (bidirectional time exchange).
+- `iburst`: (optional, boolean) if set to `true`, chrony will send a burst of packets at startup to
+  speed up the initial synchronization. Defaults to `false`.
+- `offline`: (optional, boolean) if set to `true`, the source is marked as offline initially. This
+  is useful for sources that are not always available (e.g., sources that require network
+  connectivity that may not be present at boot time). Defaults to `false`.
+
+:::note
+
+If you need to synchronize the date/time befor Agama starts (e.g., if your system does not have a
+clock), check the [`rd.ntp` boot option](./../boot_options).

--- a/docs/user/reference/profile/ntp.md
+++ b/docs/user/reference/profile/ntp.md
@@ -44,5 +44,7 @@ source can specify:
 
 :::note
 
-If you need to synchronize the date/time befor Agama starts (e.g., if your system does not have a
+If you need to synchronize the date/time before Agama starts (e.g., if your system does not have a
 clock), check the [`rd.ntp` boot option](./../boot_options).
+
+:::


### PR DESCRIPTION
Add the documentation about setting up NTP.

* Briefly document `rd.ntp`.
* Describe the `ntp` option of the configuration file.
* Update the AutoYaST compatibility document.