### PR TITLE
CLI reference updated for the switch to clap::Builder

### DIFF
--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -186,7 +186,7 @@ Analyze the system.
 
 In Agama's jargon, the term 'probing' refers to the process of 'analyzing' the system. This includes
 reading software repositories, analyzing storage devices, and more. The 'probe' command initiates
-this analysis process and returns immediately. TODO: do we really need a "probe" action?
+this analysis process and returns immediately.
 
 **Usage:** `agama probe`
 

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -36,7 +36,7 @@ installation process, check the [corresponding section](/docs/overview/cli) of t
 
 ## `agama`
 
-Agama's command-line interface
+Agama's command-line interface.
 
 This program allows inspecting or changing Agama's configuration, handling installation profiles,
 starting the installation, monitoring the process, etc.
@@ -93,7 +93,7 @@ the "load" subcommand.
 - `show` — Generate an installation profile with the current settings
 - `load` — Read and load a profile
 - `validate` — Validate a profile using JSON Schema
-- `generate` — Generate and print a native Agama JSON configuration from any kind and location.
+- `generate` — Generate and print a native Agama JSON configuration from any kind and location
 - `edit` — Edit and update installation option using an external editor
 
 ## `agama config show`
@@ -123,7 +123,7 @@ Read and load a profile
 
 ## `agama config validate`
 
-Validate a profile using JSON Schema
+Validate a profile using JSON Schema.
 
 Schema is available at /usr/share/agama/schema/profile.schema.json Note: validation is always done
 as part of all other "agama config" commands.
@@ -342,7 +342,7 @@ Print the used token to the standard output
 
 ## `agama download`
 
-Download file from a given (AutoYaST) URL
+Download file from a given (AutoYaST) URL.
 
 The purpose of this command is to download files using AutoYaST supported schemas (e.g. device://).
 It can be used to download additional scripts, configuration files and so on. You can use it for

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -304,8 +304,9 @@ operations. You can log in by specifying the root password through the "auth log
 successful authentication, the server returns a JSON Web Token (JWT) which is stored to authenticate
 the following requests.
 
-If you run this program as root, you can skip the authentication step because it automatically uses
-the master token at /run/agama/token. Only the root user must have access to such a file.
+If you run this program locally as root, you can skip the authentication step because it
+automatically uses the master token at /run/agama/token. Only the root user must have access to such
+a file.
 
 You can logout at any time by using the "auth logout" command, although this command does not affect
 the root user.


### PR DESCRIPTION
Agama PR: https://github.com/agama-project/agama/pull/3594

The switch revealed inconsistencies in end-of-sentence periods, now they are consistent.