### PR TITLE
Update the i18n related documentation

### DIFF
--- a/docs/devel/i18n.md
+++ b/docs/devel/i18n.md
@@ -12,30 +12,10 @@ below.
 
 ## Using translations
 
-Users have two ways how to change the used language in the Agama interface.
-
-### Language selector
-
-The sidebar of the web UI contains a component that allows to change the language. It was introduced
-in Agama 5 and it is the recommended way. The list of supported languages is read from the
+The top bar in the web UI contains a component that allows to change the language. The list of
+supported languages is read from the
 [languages.json](https://github.com/agama-project/agama/blob/master/web/src/languages.json) file.
 Check the [The web front-end](#the-web-front-end) for further details.
-
-### URL query parameter
-
-When using a remote installation it is possible to set the used language via an URL query parameter.
-This is an expert option.
-
-To change the language append the `?lang=<locale>` query to the URL when accessing the Agama
-installer. The `locale` string uses the [RFC 5646](https://www.rfc-editor.org/rfc/rfc5646.html) but
-the usual Linux locale format is supported too, e.g. `cs_CZ`.
-
-It is the user responsibility to use a correct locale name. When using a wrong name the translations
-might be broken, displayed only partially or even not at all.
-
-Changing the language causes reloading the page, in some situations this could cause losing some
-entered values on the current page. Therefore it is recommended to change the language at the very
-beginning.
 
 ## Translations
 
@@ -308,6 +288,13 @@ the formatting specifiers.
 _Note: You cannot use HTML tags in the translated texts, React automatically escapes all special
 HTML characters like `<>&`. That is different to YaST where we can use HTML tags in rich text
 messages._
+
+_Note: The sprintf function also supports [named
+arguments](https://github.com/alexei/sprintf.js#named-arguments) but this should be rather avoided.
+The problem is that the current GNU xgettext (v1.0) does not recognize this style and does not add
+the `javascript-format` flag to that string. That means a typo in the argument name or a missing
+argument in a translation will not be detected which makes this style more error prone than the
+usual `%s` style._
 
 It is recommended to avoid building texts from several parts translated separately. This is error
 prone because the translators will not see the complete final text and might translate some parts

--- a/docs/devel/i18n.md
+++ b/docs/devel/i18n.md
@@ -71,16 +71,19 @@ flowchart LR
    AW[Agama-weblate<br>repository]
    W[Weblate]
 
-   A -->|"GitHub Action<br>update POT<br>(daily)"| AW
+   A -->|"GitHub Action<br>update POT<br>(after every commit)"| AW
    AW -->|"GitHub Actions<br>merge PO<br>(weekly)"| A
    AW -->|GitHub webhooks,<br>git pull| W
    W -->|git push| AW
 ```
 
-We do not want to spam the Weblate tool with every trivial change in the texts and the other way
-round, we do not need to get dozen commits from the Weblate every day with updated translations.
-This would be especially annoying before releasing a new version where we might want to accept only
-unnecessary changes to not break something at the very last minute.
+The changed texts are updated in the Weblate repository automatically after every commit to the
+Agama repository.
+
+We do not need to get dozen commits from the Weblate every day with updated translations. This would
+be especially annoying before releasing a new version where we might want to accept only unnecessary
+changes to not break something at the very last minute. So the translations are merged back once a
+week.
 
 The agama-weblate repository uses webhooks to notify the Weblate instance of any change. Changes in
 the repository should be visible in Weblate in matter of seconds.
@@ -113,7 +116,8 @@ GitHub action.
   GitHub. If there is no change in the files besides the timestamps then the file it is not uploaded
   to `agama-weblate`.
 
-This action is run daily, but it can be started manually if needed. Go to the
+This action run after every commit which modifies any file which might contain translated texts. If
+it for some reason fails it can be started manually. Go to the
 [weblate-update-pot.yml](https://github.com/agama-project/agama/actions/workflows/weblate-update-pot.yml)
 action detail and use the "Run workflow" option at the top of the page.
 

--- a/docs/devel/i18n.md
+++ b/docs/devel/i18n.md
@@ -52,7 +52,7 @@ flowchart LR
    W[Weblate]
 
    A -->|"GitHub Action<br>update POT<br>(after every commit)"| AW
-   AW -->|"GitHub Actions<br>merge PO<br>(weekly)"| A
+   AW -->|"GitHub Action<br>merge PO<br>(weekly)"| A
    AW -->|GitHub webhooks,<br>git pull| W
    W -->|git push| AW
 ```
@@ -289,12 +289,12 @@ _Note: You cannot use HTML tags in the translated texts, React automatically esc
 HTML characters like `<>&`. That is different to YaST where we can use HTML tags in rich text
 messages._
 
-_Note: The sprintf function also supports [named
-arguments](https://github.com/alexei/sprintf.js#named-arguments) but this should be rather avoided.
-The problem is that the current GNU xgettext (v1.0) does not recognize this style and does not add
-the `javascript-format` flag to that string. That means a typo in the argument name or a missing
-argument in a translation will not be detected which makes this style more error prone than the
-usual `%s` style._
+_Note: The sprintf function also supports
+[named arguments](https://github.com/alexei/sprintf.js#named-arguments) but this should be rather
+avoided. The problem is that the current GNU xgettext (v1.0) does not recognize this style and does
+not add the `javascript-format` flag to that string. That means a typo in the argument name or a
+missing argument in a translation will not be detected which makes this style more error prone than
+the usual `%s` style._
 
 It is recommended to avoid building texts from several parts translated separately. This is error
 prone because the translators will not see the complete final text and might translate some parts


### PR DESCRIPTION
- The `lang` URL query parameter has been removed
- The translations in Weblate are now updated immediately (to minimize possible conflicts when translators translate some recently updated text)
- Discourage using named parameters in `sprintf()` function